### PR TITLE
Exists-step semantics and Graph-based interference detection

### DIFF
--- a/pypmt/config.py
+++ b/pypmt/config.py
@@ -3,7 +3,7 @@ import logging
 
 from unified_planning.shortcuts import CompilationKind
 from pypmt.encoders.R2E import EncoderRelaxed2Exists
-from pypmt.encoders.basic import EncoderForall, EncoderSequential
+from pypmt.encoders.basic import EncoderForall, EncoderSequential, EncoderExists
 from pypmt.encoders.SequentialLifted import EncoderSequentialLifted
 from pypmt.encoders.SequentialQFUF import EncoderSequentialQFUF
 from pypmt.encoders.OMT import EncoderSequentialOMT
@@ -79,6 +79,13 @@ class Config:
             "compilationlist": grounded_encoders_default_compilation_list,
             "propagator": None,
             "description": "A parallel encoding with forall-step semantics"
+        },
+        "exists": {
+            "encoder": EncoderExists,
+            "search": SMTSearch,
+            "compilationlist": grounded_encoders_default_compilation_list,
+            "propagator": None,
+            "description": "A parallel encoding with exists-step semantics"
         },
         "r2e": {
             "encoder": EncoderRelaxed2Exists,

--- a/pypmt/modifiers/modifierParallel.py
+++ b/pypmt/modifiers/modifierParallel.py
@@ -80,12 +80,18 @@ class ParallelModifier(Modifier):
 
         # main body of the function
         start_time = time.time()
-        mutexes = set()
         actions = encoder.task.actions
 
+        def add_edge(action1, action2):
+            self.graph.add_edge(action1.name, action2.name)
+
+        for action in actions:
+            self.graph.add_node(action.name)
+
+        # Iterate over actions to identify mutex pairs
         for i, action_1 in enumerate(actions):
-            for action_2 in actions[i+1:]:
-                add_a1, del_a1, num_1, pre_1 = data_actions[action_1]
+            add_a1, del_a1, num_1, pre_1 = data_actions[action_1]
+            for action_2 in actions[i + 1:]:
                 add_a2, del_a2, num_2, pre_2 = data_actions[action_2]
 
                 # Condition 1: can a1 prohibit the execution of a2 or vice-versa?

--- a/pypmt/modifiers/modifierParallel.py
+++ b/pypmt/modifiers/modifierParallel.py
@@ -68,10 +68,6 @@ class ParallelModifier(Modifier):
                     preconditions.add(fluent)
             return preconditions
 
-        def mutex(a1, a2):
-            return z3.Not(z3.And(encoder.get_action_var(a1.name, 0),
-                                 encoder.get_action_var(a2.name, 0)))
-
         # we avoid computing some of those twice on the following double for loop
         start_time = time.time()
         data_actions = {}


### PR DESCRIPTION
Added exists-step encoding which uses the graph to the configuration.

Added an encoder for exists-step, and fixed the description for forall-step.

Added support for ordering of actions in a step in extract_plan() of the basic encoder. The encoder now takes an argument of if it is parallel or not, to retain original functionality for extracting final plan without the graph.

Added graph based lazy interference detection for the parallel modifier, to allow exists step to follow an action ordering in steps when creating plans, as well as have necessary information when adding propagators.


